### PR TITLE
Re-enabled Generated Index for Pub & Tools

### DIFF
--- a/cypress/e2e/documentation.cy.js
+++ b/cypress/e2e/documentation.cy.js
@@ -49,30 +49,40 @@ describe('Docusarus user interactions', () => {
     cy.visit(url)
     cy.get(':nth-child(2) > .menu__list-item-collapsible > .clean-btn').click()
     cy.get(
-      ':nth-child(2) > .menu__list > :nth-child(2) > .menu__list-item-collapsible > .clean-btn'
+      ':nth-child(2) > :nth-child(4) > .menu__list-item-collapsible'
     ).click()
     cy.get(
-      ':nth-child(2) > .menu__list > .theme-doc-sidebar-item-link > .menu__link'
+      ':nth-child(2) > :nth-child(4) > .menu__list > :nth-child(2) > .menu__list-item-collapsible'
+    ).click()
+    cy.get(
+      ':nth-child(2) > :nth-child(4) > .menu__list > :nth-child(2) > .menu__list > :nth-child(5)  > .menu__list-item-collapsible'
+    ).click()
+    cy.get(
+      ':nth-child(2) > :nth-child(4) > .menu__list > :nth-child(2) > .menu__list > :nth-child(5)  > .menu__list > :nth-child(3) > .menu__link'
     ).click()
     cy.location().should(loc => {
       expect(loc.href).to.eq(
-        `${HOST}/documentation/publications/aggregate-disclosure-reports/ad-changes`
+        `${HOST}/documentation/publications/modified-lar/resources/data-dictionaries/mlar-dd-2019`
       )
     })
   })
-  it('Interacts with nested documentation via category selector', () => {
-    cy.visit(url)
-    cy.get(':nth-child(2) > .menu__list-item-collapsible > .menu__link').click()
-    cy.wait(1000)
-    cy.get(':nth-child(2) > .card').click()
-    cy.wait(1000)
-    cy.get('.card').click()
-    cy.location().should(loc => {
-      expect(loc.href).to.eq(
-        `${HOST}/documentation/publications/aggregate-disclosure-reports/ad-changes`
-      )
-    })
-  })
+
+  // Test for Nested Category Pages.
+  // it('Interacts with nested documentation via category selector', () => {
+  //   cy.visit(url)
+  //   cy.get(':nth-child(2) > .menu__list-item-collapsible > .menu__link').click()
+  //   cy.wait(1000)
+  //   cy.get(':nth-child(2) > .card').click()
+  //   cy.wait(1000)
+  //   cy.get('.card').click()
+  //   cy.location().should(loc => {
+  //     expect(loc.href).to.eq(
+  //       `${HOST}/documentation/publications/aggregate-disclosure-reports/ad-changes`
+  //     )
+  //   })
+  // })
+
+  
   it('Interacts with table of contents on single doc', () => {
     cy.visit(url)
     cy.get(':nth-child(1) > .card').click()

--- a/sidebars.js
+++ b/sidebars.js
@@ -36,6 +36,9 @@ const sidebars = {
     {
       type: "category",
       label: "Publications",
+      link: {
+        type: "generated-index",
+      },
       collapsed: true,
       items: [
         {
@@ -99,6 +102,9 @@ const sidebars = {
     {
       type: "category",
       label: "Tools",
+      link: {
+        type: "generated-index",
+      },
       collapsed: true,
       items: [
         {

--- a/sidebars.js
+++ b/sidebars.js
@@ -36,10 +36,10 @@ const sidebars = {
     {
       type: "category",
       label: "Publications",
+      collapsed: true,
       link: {
         type: "generated-index",
       },
-      collapsed: true,
       items: [
         {
           type: "category",

--- a/src/theme/Navbar/Content/links.js
+++ b/src/theme/Navbar/Content/links.js
@@ -41,6 +41,8 @@ export const defaultLinks = [
   { name: 'Documentation', href: '', 
     submenu: [
       { name: 'FAQs', href: '/documentation/' },
+      { name: 'Publications', href: '/documentation/category/publications' },
+      { name: 'Tools', href: '/documentation/category/tools' },
       { name: 'Developer APIs', href: '/documentation/category/developer-apis' },
       { name: 'Updates', href: '/updates-notes' },
     ]


### PR DESCRIPTION
Previously disabled generated index and now re-enabled. Should fix failing Cypress tests.