### PR TITLE
[Cypress] Fix 2023 failing Algolia Search test

### DIFF
--- a/cypress/e2e/documentation.cy.js
+++ b/cypress/e2e/documentation.cy.js
@@ -118,7 +118,10 @@ describe('Covers Filing Instructions Guide (FIG) interactions', () => {
     cy.visit(`${HOST}/documentation/fig/2023/overview`)
     cy.get('.DocSearch').click()
     cy.get('#docsearch-input').type('Loan/Application Register format')
-    cy.get('#docsearch-item-0 > a > .DocSearch-Hit-Container').contains('Loan/Application Register format').click()
+    cy.get('.DocSearch-Hit-source').invoke('remove') // Remove the HMTL element that is blocking Cypress from clicking
+    cy.get('#docsearch-item-0 > a > .DocSearch-Hit-Container')
+      .contains('Loan/Application Register format')
+      .click()
     cy.get('[id^=33--loanapplication-register-format]').contains('Loan/Application Register format')
   })
   it('Navigates to FIG year (2023) and ensures 2023 version is properly displayed and allows navigation to the latest FIG via the banner link', () => {


### PR DESCRIPTION
Closes [#2259](https://github.com/cfpb/hmda-frontend/issues/2259)

Update Cypress test to remove the blocking element before trying to click. 

### Before

<img width="509" alt="image" src="https://github.com/user-attachments/assets/04005ccf-2241-4194-b97f-e04f83fdaf1e">

### After

<img width="508" alt="image" src="https://github.com/user-attachments/assets/14aa9240-8db6-43ca-a720-c5a520084fa2">
