### PR TITLE
Standardize FIG edit anchor link format

### DIFF
--- a/fig_versioned_docs/version-2021/tables/TableMaker.jsx
+++ b/fig_versioned_docs/version-2021/tables/TableMaker.jsx
@@ -33,8 +33,11 @@ export const TableMaker = ({ jsonData, tableNumber, tableName }) => {
           modifiedValue = cellValue
             .replace(/ (\d+)\)/g, '<br>$1) ') // Add <br> before space-digit-period-space
         }
-        else if (columnKey == 'Data Field Number' || columnKey == "Edit ID") {
+        else if (columnKey == 'Data Field Number') {
           modifiedValue = '<span class="anchor anchorWithStickyNavbar_LWe7" id="table' + tableNumber + '-' + cellValue + '">' + cellValue + '</span>' + '<a class="hash-link" href="#table' + tableNumber + '-' + cellValue + '"></a>'
+        }
+        else if (columnKey == "Edit ID") {
+          modifiedValue = '<span class="anchor anchorWithStickyNavbar_LWe7" id="edit-' + cellValue + '">' + cellValue + '</span>' + '<a class="hash-link" href="#edit-' + cellValue + '"></a>'
         }
         
         return <div dangerouslySetInnerHTML={{ __html: modifiedValue }} />;

--- a/fig_versioned_docs/version-2022/tables/TableMaker.jsx
+++ b/fig_versioned_docs/version-2022/tables/TableMaker.jsx
@@ -33,8 +33,11 @@ export const TableMaker = ({ jsonData, tableNumber, tableName }) => {
           modifiedValue = cellValue
             .replace(/ (\d+)\)/g, '<br>$1) ') // Add <br> before space-digit-period-space
         }
-        else if (columnKey == 'Data Field Number' || columnKey == "Edit ID") {
+        else if (columnKey == 'Data Field Number') {
           modifiedValue = '<span class="anchor anchorWithStickyNavbar_LWe7" id="table' + tableNumber + '-' + cellValue + '">' + cellValue + '</span>' + '<a class="hash-link" href="#table' + tableNumber + '-' + cellValue + '"></a>'
+        }
+        else if (columnKey == "Edit ID") {
+          modifiedValue = '<span class="anchor anchorWithStickyNavbar_LWe7" id="edit-' + cellValue + '">' + cellValue + '</span>' + '<a class="hash-link" href="#edit-' + cellValue + '"></a>'
         }
         
         return <div dangerouslySetInnerHTML={{ __html: modifiedValue }} />;

--- a/fig_versioned_docs/version-2023/tables/TableMaker.jsx
+++ b/fig_versioned_docs/version-2023/tables/TableMaker.jsx
@@ -33,8 +33,11 @@ export const TableMaker = ({ jsonData, tableNumber, tableName }) => {
           modifiedValue = cellValue
             .replace(/ (\d+)\)/g, '<br>$1) ') // Add <br> before space-digit-period-space
         }
-        else if (columnKey == 'Data Field Number' || columnKey == "Edit ID") {
+        else if (columnKey == 'Data Field Number') {
           modifiedValue = '<span class="anchor anchorWithStickyNavbar_LWe7" id="table' + tableNumber + '-' + cellValue + '">' + cellValue + '</span>' + '<a class="hash-link" href="#table' + tableNumber + '-' + cellValue + '"></a>'
+        }
+        else if (columnKey == "Edit ID") {
+          modifiedValue = '<span class="anchor anchorWithStickyNavbar_LWe7" id="edit-' + cellValue + '">' + cellValue + '</span>' + '<a class="hash-link" href="#edit-' + cellValue + '"></a>'
         }
         
         return <div dangerouslySetInnerHTML={{ __html: modifiedValue }} />;

--- a/fig_versioned_docs/version-2024/tables/TableMaker.jsx
+++ b/fig_versioned_docs/version-2024/tables/TableMaker.jsx
@@ -34,8 +34,11 @@ export const TableMaker = ({ jsonData, tableNumber, tableName }) => {
           modifiedValue = cellValue
             .replace(/ (\d+)\)/g, '<br>$1) ') // Add <br> before space-digit-period-space
         }
-        else if (columnKey == 'Data Field Number' || columnKey == "Edit ID") {
+        else if (columnKey == 'Data Field Number') {
           modifiedValue = '<span class="anchor anchorWithStickyNavbar_LWe7" id="table' + tableNumber + '-' + cellValue + '">' + cellValue + '</span>' + '<a class="hash-link" href="#table' + tableNumber + '-' + cellValue + '"></a>'
+        }
+        else if (columnKey == "Edit ID") {
+          modifiedValue = '<span class="anchor anchorWithStickyNavbar_LWe7" id="edit-' + cellValue + '">' + cellValue + '</span>' + '<a class="hash-link" href="#edit-' + cellValue + '"></a>'
         }
         
         return <div dangerouslySetInnerHTML={{ __html: modifiedValue }} />;

--- a/fig_versioned_docs/version-2025/tables/TableMaker.jsx
+++ b/fig_versioned_docs/version-2025/tables/TableMaker.jsx
@@ -34,8 +34,11 @@ export const TableMaker = ({ jsonData, tableNumber, tableName }) => {
           modifiedValue = cellValue
             .replace(/ (\d+)\)/g, '<br>$1) ') // Add <br> before space-digit-period-space
         }
-        else if (columnKey == 'Data Field Number' || columnKey == "Edit ID") {
+        else if (columnKey == 'Data Field Number') {
           modifiedValue = '<span class="anchor anchorWithStickyNavbar_LWe7" id="table' + tableNumber + '-' + cellValue + '">' + cellValue + '</span>' + '<a class="hash-link" href="#table' + tableNumber + '-' + cellValue + '"></a>'
+        }
+        else if (columnKey == "Edit ID") {
+          modifiedValue = '<span class="anchor anchorWithStickyNavbar_LWe7" id="edit-' + cellValue + '">' + cellValue + '</span>' + '<a class="hash-link" href="#edit-' + cellValue + '"></a>'
         }
         
         return <div dangerouslySetInnerHTML={{ __html: modifiedValue }} />;

--- a/fig_versioned_docs/version-2026/tables/TableMaker.jsx
+++ b/fig_versioned_docs/version-2026/tables/TableMaker.jsx
@@ -34,8 +34,11 @@ export const TableMaker = ({ jsonData, tableNumber, tableName }) => {
           modifiedValue = cellValue
             .replace(/ (\d+)\)/g, '<br>$1) ') // Add <br> before space-digit-period-space
         }
-        else if (columnKey == 'Data Field Number' || columnKey == "Edit ID") {
+        else if (columnKey == 'Data Field Number') {
           modifiedValue = '<span class="anchor anchorWithStickyNavbar_LWe7" id="table' + tableNumber + '-' + cellValue + '">' + cellValue + '</span>' + '<a class="hash-link" href="#table' + tableNumber + '-' + cellValue + '"></a>'
+        }
+        else if (columnKey == "Edit ID") {
+          modifiedValue = '<span class="anchor anchorWithStickyNavbar_LWe7" id="edit-' + cellValue + '">' + cellValue + '</span>' + '<a class="hash-link" href="#edit-' + cellValue + '"></a>'
         }
         
         return <div dangerouslySetInnerHTML={{ __html: modifiedValue }} />;


### PR DESCRIPTION
Edit links currently have "tableX" dynamically prepended to the edit ID, e.g. [`#table7-Q600`](https://ffiec.cfpb.gov/documentation/fig/2026/overview#table7-Q600), which makes it difficult to link to specific edits because its table number has to be known.

This PR replaces the dynamic `table` prefix with "edit", e.g. `#edit-Q600` to make linking easier.

See https://github.local/HMDA-Operations/hmda-devops/issues/5025

### Notes

- The downside is that current links to edits will no longer work. Do we have any links to edits?