### PR TITLE
fix(e2e): match tests with making 2025 the default during filing season

### DIFF
--- a/cypress/e2e/documentation.cy.js
+++ b/cypress/e2e/documentation.cy.js
@@ -3,7 +3,7 @@ const { HOST } = Cypress.env()
 const DOCS_DEFAULT_URL = `${HOST}/documentation/category/frequently-asked-questions`
 const FIG_DOCS_DEFAULT_URL = `${HOST}/documentation/fig/2025/overview` // Takes user to most current FIG document
 const CURRENT_FIG_YEAR = '2025'
-const LATEST_FIG_YEAR = '2026'
+const LATEST_FIG_YEAR = '2025'
 
 describe('General Checks', () => {
   it('Government banner is displayed and image is visible', () => {


### PR DESCRIPTION
We changed the default FIG to be 2025 a while ago to be the default during filing season (we temporarily had it set to 2026 when people were hungry for it since it was so late getting out of clearance), but the redirect FIG test still needs to be updated to 2025. This will let us deploy the latest cypress image without one of the tests failing.

## Changes
- update latest fig year to be 2025 to match what's on prod

## Testing
- Does it match the current desired behavior on prod? Yes
<img width="1434" height="229" alt="Screenshot 2026-02-12 at 1 31 33 PM" src="https://github.com/user-attachments/assets/9aa9627a-dbb4-41bc-b729-788ec4cbe781" />

- Do the tests pass now? Yes!

| Before | After |
|---|---|
| <img width="513" height="904" alt="Screenshot 2026-02-12 at 1 27 52 PM" src="https://github.com/user-attachments/assets/d0ce7076-3b53-4f10-b907-9302887dfb07" /> | <img width="539" height="510" alt="Screenshot 2026-02-12 at 1 20 20 PM" src="https://github.com/user-attachments/assets/33c412cb-bebd-4471-9a63-b377d9372125" /> |


