### PR TITLE
Adding seccomProfile to HMDA Documentation service

### DIFF
--- a/kubernetes/hmda-documentation/templates/deployment.yaml
+++ b/kubernetes/hmda-documentation/templates/deployment.yaml
@@ -26,6 +26,8 @@ spec:
           - name: GIT_COMMIT
             value: {{ .Values.commitId }}
           securityContext:
+            seccompProfile:
+              type: RuntimeDefault
             allowPrivilegeEscalation: false
             capabilities:
               drop:


### PR DESCRIPTION
In order to clear a compliance issue in Prisma Cloud we needed to add

seccompProfile: type: RuntimeDefault

to the securityContext of the HMDA Documentation Service