### PR TITLE
fix(dockerfile): bump alpine version to 3.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### Build Stage ###
 # Use node as the base image
-FROM node:20-alpine3.19 AS build-stage
+FROM node:20-alpine3.23 AS build-stage
 
 # Set the working directory to /app
 WORKDIR /app
@@ -42,7 +42,7 @@ RUN yarn build
 # RUN npm prune --production
 
 ### Run Stage ###
-FROM node:20-alpine3.19 AS run-stage
+FROM node:20-alpine3.23 AS run-stage
 COPY --from=build-stage  /app/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # Set the working directory to /app


### PR DESCRIPTION
New alpine:node version just dropped, so let's update it to fix a few security vulnerabilities

## Changes

- bumps to alpine 3.23

## Testing

1. How does it look on staging? Good! (tagged as `alpine323`)

## Notes
- We might need to follow-up with some Dockerfile additions for still vulnerable packages, but this is a good start!