### PR TITLE
Set ambassadaor by cli

### DIFF
--- a/kubernetes/hmda-documentation/values.yaml
+++ b/kubernetes/hmda-documentation/values.yaml
@@ -51,4 +51,6 @@ tolerations: []
 affinity: {}
 
 # ambassador_id: ambassador-default-1
+
+# can be set to a specific host via cli: --set ambassador_host=ffiec.cfpb.gov
 # ambassador_host: ffiec.cfpb.gov

--- a/kubernetes/hmda-documentation/values.yaml
+++ b/kubernetes/hmda-documentation/values.yaml
@@ -51,4 +51,4 @@ tolerations: []
 affinity: {}
 
 # ambassador_id: ambassador-default-1
-ambassador_host: ffiec.cfpb.gov
+# ambassador_host: ffiec.cfpb.gov


### PR DESCRIPTION
We'll want to comment out the `ambassador_host` by default just [like we did with hmda-frontend](https://github.com/cfpb/hmda-frontend/blob/5528-pin-github-actions/kubernetes/hmda-frontend/values.yaml#L54), so that we can set it manually with a helm command for staging, dev, etc.

## Changes
- comments out ambassador_host to be set by a cli command (allows for staging)

## Testing
- No changes that affect the app: just use `--set ambassador_host=ffiec.cfpb.gov` or to staging, dev, etc.

