### PR TITLE
fix(navbar): center expandable arrows

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -227,6 +227,11 @@
   padding-left: .5em;
 }
 
+.usa-nav__primary .usa-accordion__button > span {
+  display: inline-flex;
+  align-items: center;
+}
+
 @media screen and (min-width: 1500px) {
   .hmda-name {
     display: inline-block;


### PR DESCRIPTION
Ok, I dove into a rabbit hole on this one. Apparently the little arrows in the navbar haven't been centered next to the text since at least like 2024 probably? (based on my garbage-y crawl through some of the git history)

I found it while I was testing https://github.com/cfpb/hmda-combined-documentation/pull/153, which was a fun time.

## Changes
- update the span that contains the arrows in the navbar

_Before_
<img width="847" height="64" alt="Screenshot 2026-05-05 at 4 43 49 AM" src="https://github.com/user-attachments/assets/881dccdc-71d0-4bf6-a67e-89af58248937" />

_After_
<img width="837" height="63" alt="Screenshot 2026-05-05 at 4 52 32 AM" src="https://github.com/user-attachments/assets/4423e762-147c-4832-a8c1-3a43d383a750" />


## Testing
- Does it look good on staging? Yes! (tagged as `5551-resolve-docker-vulns-18-main-2`)

